### PR TITLE
ITSM-4018: use prd environment

### DIFF
--- a/files/oclapi-prd/docker-compose.yml
+++ b/files/oclapi-prd/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - "8000:8000"
     environment:
       - WAIT_FOR="mongo.openconceptlab.org:27017,redis.openconceptlab.org:6379,solr.openconceptlab.org:8983"
-      - ENVIRONMENT=${ENVIRONMENT-production}
+      - ENVIRONMENT=production
       - ROOT_PASSWORD=${ROOT_PASSWORD-Root123}
       - OCL_API_TOKEN=${OCL_API_TOKEN-891b4b17feab99f3ff7e5b5d04ccc5da7aa96da6}
       - SECRET_KEY

--- a/files/oclapi-qa/docker-compose.yml
+++ b/files/oclapi-qa/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - "8000:8000"
     environment:
       - WAIT_FOR="mongo.openconceptlab.org:27017,redis.openconceptlab.org:6379,solr.openconceptlab.org:8983"
-      - ENVIRONMENT=${ENVIRONMENT-production}
+      - ENVIRONMENT=production
       - ROOT_PASSWORD=${ROOT_PASSWORD-Root123}
       - OCL_API_TOKEN=${OCL_API_TOKEN-891b4b17feab99f3ff7e5b5d04ccc5da7aa96da6}
       - SECRET_KEY

--- a/files/oclapi-stg/docker-compose.yml
+++ b/files/oclapi-stg/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - "8000:8000"
     environment:
       - WAIT_FOR="mongo.openconceptlab.org:27017,redis.openconceptlab.org:6379,solr.openconceptlab.org:8983"
-      - ENVIRONMENT=${ENVIRONMENT-production}
+      - ENVIRONMENT=production
       - ROOT_PASSWORD=${ROOT_PASSWORD-Root123}
       - OCL_API_TOKEN=${OCL_API_TOKEN-891b4b17feab99f3ff7e5b5d04ccc5da7aa96da6}
       - SECRET_KEY

--- a/files/oclweb-prd/docker-compose.yml
+++ b/files/oclweb-prd/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     environment:
       - DATABASE_URL=postgres://${POSTGRES_USER-ocl}:${POSTGRES_PASSWORD-Ocl123}@dbweb.openconceptlab.org:5432/ocl
       - WAIT_FOR=dbweb.openconceptlab.org:5432
-      - ENVIRONMENT=${ENVIRONMENT-production}
+      - ENVIRONMENT=production
       - OCL_API_HOST=${OCL_API_HOST-http://172.17.0.1:8000}
       - OCL_API_TOKEN=${OCL_API_TOKEN-891b4b17feab99f3ff7e5b5d04ccc5da7aa96da6}
       - OCL_ANON_API_TOKEN=${OCL_ANON_API_TOKEN-891b4b17feab99f3ff7e5b5d04ccc5da7aa96da6}

--- a/files/oclweb-qa/docker-compose.yml
+++ b/files/oclweb-qa/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     environment:
       - DATABASE_URL=postgres://${POSTGRES_USER-ocl}:${POSTGRES_PASSWORD-Ocl123}@dbweb.openconceptlab.org:5432/ocl
       - WAIT_FOR=dbweb.openconceptlab.org:5432
-      - ENVIRONMENT=${ENVIRONMENT-production}
+      - ENVIRONMENT=production
       - OCL_API_HOST=${OCL_API_HOST-http://172.17.0.1:8000}
       - OCL_API_TOKEN=${OCL_API_TOKEN-891b4b17feab99f3ff7e5b5d04ccc5da7aa96da6}
       - OCL_ANON_API_TOKEN=${OCL_ANON_API_TOKEN-891b4b17feab99f3ff7e5b5d04ccc5da7aa96da6}

--- a/files/oclweb-stg/docker-compose.yml
+++ b/files/oclweb-stg/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     environment:
       - DATABASE_URL=postgres://${POSTGRES_USER-ocl}:${POSTGRES_PASSWORD-Ocl123}@dbweb.openconceptlab.org:5432/ocl
       - WAIT_FOR=dbweb.openconceptlab.org:5432
-      - ENVIRONMENT=${ENVIRONMENT-production}
+      - ENVIRONMENT=production
       - OCL_API_HOST=${OCL_API_HOST-http://172.17.0.1:8000}
       - OCL_API_TOKEN=${OCL_API_TOKEN-891b4b17feab99f3ff7e5b5d04ccc5da7aa96da6}
       - OCL_ANON_API_TOKEN=${OCL_ANON_API_TOKEN-891b4b17feab99f3ff7e5b5d04ccc5da7aa96da6}


### PR DESCRIPTION
Rafal, I think this one needs to always be production, no?


This is what happens if I try with ENVIRONMENT=qa
```
api_1     | Starting the server
api_1     | Traceback (most recent call last):
api_1     |   File "manage.py", line 11, in <module>
api_1     |     execute_from_command_line(sys.argv)
api_1     |   File "/usr/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 453, in execute_from_command_line
api_1     |     utility.execute()
api_1     |   File "/usr/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 392, in execute
api_1     |     self.fetch_command(subcommand).run_from_argv(self.argv)
api_1     |   File "/usr/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 263, in fetch_command
api_1     |     app_name = get_commands()[subcommand]
api_1     |   File "/usr/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 109, in get_commands
api_1     |     apps = settings.INSTALLED_APPS
api_1     |   File "/usr/local/lib/python2.7/site-packages/django/conf/__init__.py", line 53, in __getattr__
api_1     |     self._setup(name)
api_1     |   File "/usr/local/lib/python2.7/site-packages/django/conf/__init__.py", line 48, in _setup
api_1     |     self._wrapped = Settings(settings_module)
api_1     |   File "/usr/local/lib/python2.7/site-packages/django/conf/__init__.py", line 134, in __init__
api_1     |     raise ImportError("Could not import settings '%s' (Is it on sys.path?): %s" % (self.SETTINGS_MODULE, e))
api_1     | ImportError: Could not import settings 'oclapi.settings.qa' (Is it on sys.path?): No module named qa
```

I changed manually in qa. 