### PR TITLE
ITSM-4004: Add pmtool to Jetstream

### DIFF
--- a/files/openhim/README.md
+++ b/files/openhim/README.md
@@ -1,0 +1,36 @@
+## Description
+
+Run OpenHIM for use by the [Open Concept Lab](https://openconceptlab.org/).
+
+The docker images are generated and maintained by [Jembi](https://jembi.org/).
+
+## Running it locally
+
+```
+$ docker-compose up
+```
+
+OpenHIM console will be available on http://localhost/
+
+Use _CTRL + C_ to stop all containers.
+
+To clear out stopped containers after stopping:
+
+```
+$ docker-compose down
+```
+
+To free up all resources (including daa volume) after stopping:
+
+```
+$ docker-compose down -v
+```
+
+## Initial setup
+
+The first time OpenHIM is run, authenticate using these credentials:
+
+* E-mail address: **root**<span>**@**</span>**openmrs.org**
+* Password: **openhim-password**
+
+On first successful login, you should be prompted to reset the root password. Use a tool like [LastPass](https://www.lastpass.com/) or site like [passwordgenerator.net](https://passwordsgenerator.net/) to generate a secure password at least 20 characters long for the root password.

--- a/files/openhim/deploy.env
+++ b/files/openhim/deploy.env
@@ -1,0 +1,1 @@
+DESTROY_VOLUMES=false

--- a/files/openhim/docker-compose.yml
+++ b/files/openhim/docker-compose.yml
@@ -1,0 +1,50 @@
+version: '3'
+ 
+services:
+  mongo:
+    container_name: mongo
+    image: mongo:3.4
+    volumes:
+      - openhim-data:/data/db
+    restart: always
+    healthcheck:
+      test: echo 'db.stats().ok' | mongo localhost:27017/test --quiet
+      interval: 1m
+      timeout: 3s
+      retries: 3
+ 
+  openhim-core:
+    container_name: openhim-core
+    image: jembi/openhim-core
+    environment:
+      mongo_url: mongodb://mongo/openhim
+      mongo_atnaUrl: "mongodb://mongo/openhim"
+    ports:
+      - "8080:8080"
+      - "5000:5000"
+      - "5001:5001"
+    depends_on:
+      - mongo
+    restart: always
+    healthcheck:
+      test: ["CMD", "curl", "-fk", "https://localhost:8080/heartbeat"]
+      interval: 1m30s
+      timeout: 5s
+      retries: 3
+ 
+  openhim-console:
+    container_name: openhim-console
+    image: jembi/openhim-console
+    ports:
+      - "8100:80"
+    volumes:
+      - ./openhim-console-config.json:/usr/share/nginx/html/config/default.json
+    restart: always
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost/config/default.json"]
+      interval: 1m30s
+      timeout: 5s
+      retries: 3
+
+volumes:
+  openhim-data:

--- a/files/openhim/openhim-console-config.json
+++ b/files/openhim/openhim-console-config.json
@@ -1,0 +1,13 @@
+{
+  "version": "1.10.0",
+  "minimumCoreVersion": "3.4.0",
+  "protocol": "https",
+  "host": "localhost",
+  "port": 8080,
+  "title": "Admin Console",
+  "footerTitle": "OpenHIM Administration Console",
+  "footerPoweredBy": "<a href='http://openhim.org/' target='_blank'>Powered by OpenHIM</a>",
+  "loginBanner": "",
+  "mediatorLastHeartbeatWarningSeconds": 60,
+  "mediatorLastHeartbeatDangerSeconds": 120
+}

--- a/files/pmtool/README.md
+++ b/files/pmtool/README.md
@@ -1,0 +1,25 @@
+## Description
+
+Run Project Management Tool, used for tracking various aspects of development for the OpenMRS Community.
+
+## Running it locally
+
+```
+$ docker-compose up
+```
+
+PM tool will be available on http://localhost/
+
+Use _CTRL + C_ to stop all containers.
+
+To clear out stopped containers after stopping:
+
+```
+$ docker-compose down
+```
+
+## Running in production
+
+```
+$ PMTOOL_PORT=8080 docker-compose up -d
+```

--- a/files/pmtool/docker-compose.yml
+++ b/files/pmtool/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3'
+
+services:
+  pmtool:
+    image: openmrs/openmrs-contrib-pmtool
+    ports:
+      - ${PMTOOL_PORT-80}:3000
+    restart: always
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost/"]
+      interval: 1m30s
+      timeout: 3s
+      retries: 3


### PR DESCRIPTION
This PR is the initial step to getting pmtool migrated from Darius' self-hosted server into Jetstream ([ITSM-4004](https://issues.openmrs.org/browse/ITSM-4004)).

At this point, the pmtool is a simple node app that is just a mash up of other data sources, so there's no database and no secrets. Rather than hardcoding the port for the host, I've made it a `PMTOOL_PORT` env variable, so the host can choose an available port (e.g., `$ PMTOOL_PORT=8123 docker-compose up -d`). I hope that's okay. 😄 