### PR TITLE
ITSM-4004: Add pmtool to Jetstream

### DIFF
--- a/files/pmtool/README.md
+++ b/files/pmtool/README.md
@@ -1,0 +1,25 @@
+## Description
+
+Run Project Management Tool, used for tracking various aspects of development for the OpenMRS Community.
+
+## Running it locally
+
+```
+$ docker-compose up
+```
+
+PM tool will be available on http://localhost/
+
+Use _CTRL + C_ to stop all containers.
+
+To clear out stopped containers after stopping:
+
+```
+$ docker-compose down
+```
+
+## Running in production
+
+```
+$ PMTOOL_PORT=8080 docker-compose up -d
+```

--- a/files/pmtool/docker-compose.yml
+++ b/files/pmtool/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3'
+
+services:
+  pmtool:
+    image: openmrs/openmrs-contrib-pmtool
+    ports:
+      - ${PMTOOL_PORT-80}:3000
+    restart: always
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost/"]
+      interval: 1m30s
+      timeout: 3s
+      retries: 3


### PR DESCRIPTION
Cleaned up PR (since [#14](https://github.com/openmrs/openmrs-contrib-ansible-docker-compose/pull/14) was accidentally created from a prior branch instead of master).

At this point, the pmtool is a simple node app that is just a mash up of other data sources, so there's no database and no secrets. Rather than hardcoding the port for the host, I've made it a `PMTOOL_PORT` env variable, so the host can choose an available port (e.g., `$ PMTOOL_PORT=8123 docker-compose up -d`). I hope that's okay. 😄 