### PR TITLE
Adding psbrandt's shields for openmrs

### DIFF
--- a/files/shields/README.md
+++ b/files/shields/README.md
@@ -1,0 +1,6 @@
+## Description
+
+There's nothing unusual about this project. Use standard commands:
+
+    docker-compose up
+    docker-compose down

--- a/files/shields/docker-compose.yml
+++ b/files/shields/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.7"
+
+services:
+  app:
+    image: openmrsinfra/shields:latest
+    restart: "always"
+    ports:
+      - "8083:3033"
+    environment:
+      - NODE_ENV=production
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3033/custom/a/b/red"]
+      timeout: 5s


### PR DESCRIPTION
Pascal built and hosted shields years ago and we've been using it within the community to show shields (badges) for modules & build statuses. A while ago, Pascal instance went down. Since then, our shields designed to show build statuses in the Development category of Talk have looked like this:
![image](https://user-images.githubusercontent.com/860834/80782545-9e69eb00-8b44-11ea-97ce-28cb4498031e.png)
While Pascal's little app needs some updating & relies on some defunct npm dependencies. It's pretty small & harmless, so I think we should just move it into our infrastructure for now.

I've already forked his repo into [openmrs/openmrs-contrib-shields](https://github.com/openmrs/openmrs-contrib-shields), dockerized it, and added it to openmrsinfra's docker hub builds. So, there's a shiny new `openmrsinfra/shield` container just begging to be deployed.

I'm assuming we'll put this on `mokolo` with our other tools, so I'm setting it to use port 8083, in anticipation of hosting it there.