### PR TITLE
OCLOMRS-922: Extra slash in Subscription URL

### DIFF
--- a/files/oclclient-demo/docker-compose.yml
+++ b/files/oclclient-demo/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   oclclient:
     image: openmrs/ocl-client:demo
     environment:
-      - OCL_API_HOST=${OCL_API_HOST:-https://api.demo.openconceptlab.org/}
+      - OCL_API_HOST=${OCL_API_HOST:-https://api.demo.openconceptlab.org}
       - TRADITIONAL_OCL_HOST=${TRADITIONAL_OCL_HOST:-https://demo.openconceptlab.org}
       - ENVIRONMENT=${ENVIRONMENT:-demo}
     ports:

--- a/files/oclclient-prd/docker-compose.yml
+++ b/files/oclclient-prd/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   oclclient:
     image: openmrs/ocl-client:prd
     environment:
-      - OCL_API_HOST=${OCL_API_HOST:-https://api.openconceptlab.org/}
+      - OCL_API_HOST=${OCL_API_HOST:-https://api.openconceptlab.org}
       - TRADITIONAL_OCL_HOST=${TRADITIONAL_OCL_HOST:-https://openconceptlab.org}
       - ENVIRONMENT=${ENVIRONMENT:-prd}
     ports:

--- a/files/oclclient-qa/docker-compose.yml
+++ b/files/oclclient-qa/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   oclclient:
     image: openmrs/ocl-client:qa
     environment:
-      - OCL_API_HOST=${OCL_API_HOST:-https://api.qa.openconceptlab.org/}
+      - OCL_API_HOST=${OCL_API_HOST:-https://api.qa.openconceptlab.org}
       - TRADITIONAL_OCL_HOST=${TRADITIONAL_OCL_HOST:-https://qa.openconceptlab.org}
       - ENVIRONMENT=${ENVIRONMENT:-qa}
     ports:

--- a/files/oclclient-qa2/docker-compose.yml
+++ b/files/oclclient-qa2/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   oclclient:
     image: openmrs/ocl-client:qa
     environment:
-      - OCL_API_HOST=${OCL_API_HOST:-https://api.qa2.aws.openconceptlab.org/}
+      - OCL_API_HOST=${OCL_API_HOST:-https://api.qa2.aws.openconceptlab.org}
       - TRADITIONAL_OCL_HOST=${TRADITIONAL_OCL_HOST:-https://qa2.aws.openconceptlab.org}
       - ENVIRONMENT=${ENVIRONMENT:-qa}
     ports:

--- a/files/oclclient-stg/docker-compose.yml
+++ b/files/oclclient-stg/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   oclclient:
     image: openmrs/ocl-client:stg
     environment:
-      - OCL_API_HOST=${OCL_API_HOST:-https://api.staging.openconceptlab.org/}
+      - OCL_API_HOST=${OCL_API_HOST:-https://api.staging.openconceptlab.org}
       - TRADITIONAL_OCL_HOST=${TRADITIONAL_OCL_HOST:-https://staging.openconceptlab.org}
       - ENVIRONMENT=${ENVIRONMENT:-stg}
     ports:


### PR DESCRIPTION
What I did:
 I  changed these files: 
[oclclient-qa/docker-compose.yml](https://github.com/openmrs/openmrs-contrib-ansible-docker-compose/blob/master/files/oclclient-qa/docker-compose.yml)
[oclclient-prd/docker-compose.yml](https://github.com/openmrs/openmrs-contrib-ansible-docker-compose/blob/master/files/oclclient-prd/docker-compose.yml)
 [oclclient-stg/docker-compose.yml](https://github.com/openmrs/openmrs-contrib-ansible-docker-compose/blob/master/files/oclclient-stg/docker-compose.yml)
 [ oclclient-qa2/docker-compose.yml](https://github.com/openmrs/openmrs-contrib-ansible-docker-compose/blob/master/files/oclclient-qa2/docker-compose.yml) 
 [oclclient-demo/docker-compose.yml](https://github.com/openmrs/openmrs-contrib-ansible-docker-compose/blob/master/files/oclclient-demo/docker-compose.yml)
from:

- OCL_API_HOST=${OCL_API_HOST:-https://api.openconceptlab.org/}

To :

- OCL_API_HOST=${OCL_API_HOST:-https://api.openconceptlab.org} 

to remove the trailing slash




Issue worked on:
https://issues.openmrs.org/browse/TRUNK-5989