### PR TITLE
fixed the distro.platform file with the 2.5.8 required info

### DIFF
--- a/files/mdsbuilder/openmrs-distro.properties
+++ b/files/mdsbuilder/openmrs-distro.properties
@@ -1,7 +1,7 @@
 name=Mdsbuilder
 version=1.0.0
-distro.platform=2.4.2
-omod.metadatasharing=1.8.0
-omod.metadatamapping=1.4.0
-omod.dataexchange=1.3.7
-omod.legacyui=1.8.3
+distro.platform=2.5.8
+omod.metadatasharing=1.9.0
+omod.metadatamapping=1.6.0
+omod.dataexchange=1.3.8
+omod.legacyui=1.13.0


### PR DESCRIPTION
I changed the distro.platform file with the correct content to enable Reference Application 2.13.0 to run on platform 2.5.8 version.