### PR TITLE
upgrade mariadb version in test3 and o3 to match dev3

### DIFF
--- a/files/emr-3-demo/docker-compose.yml
+++ b/files/emr-3-demo/docker-compose.yml
@@ -49,7 +49,7 @@ services:
 
   # MariaDB
   db:
-    image: mariadb:10.8.2
+    image: mariadb:10.11.7
     restart: "unless-stopped"
     command: "mysqld --character-set-server=utf8 --collation-server=utf8_general_ci"
     environment:

--- a/files/emr-3-qa/docker-compose.yml
+++ b/files/emr-3-qa/docker-compose.yml
@@ -49,7 +49,7 @@ services:
 
   # MariaDB
   db:
-    image: mariadb:10.8.2
+    image: mariadb:10.11.7
     restart: "unless-stopped"
     command: "mysqld --character-set-server=utf8 --collation-server=utf8_general_ci"
     environment:

--- a/files/emr-3-uganda/docker-compose.yml
+++ b/files/emr-3-uganda/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.7'
 services:
   # MariaDB
   db:
-    image: mariadb:10.8.2
+    image: mariadb:10.11.7
     restart: "unless-stopped"
     command: "mysqld --character-set-server=utf8 --collation-server=utf8_general_ci"
     healthcheck:


### PR DESCRIPTION
We've been using `mariadb:10.11.7` in dev3 for 2 months without issues. I think we can upgrade in other instances as well.