### PR TITLE
INFRA-119: ensure wordpress docker image is the latest

### DIFF
--- a/files/wordpress/docker-compose.yml
+++ b/files/wordpress/docker-compose.yml
@@ -3,7 +3,8 @@ version: '3.1'
 services:
 
   wordpress:
-    image: wordpress:6.0.1
+    # using latest as wordpress is configured to automatically upgrade
+    image: wordpress:latest
     restart: always
     depends_on:
       - mysql


### PR DESCRIPTION
This is wordpress, so... we enabled automatic upgrades everywhere. 

<img width="537" height="299" alt="Screenshot 2025-08-24 at 7 20 34 PM" src="https://github.com/user-attachments/assets/34903dd9-9cb4-4d74-8d74-d9aa93bf4b6d" />

I thought the volumes were enough to get this to work, but clearly not